### PR TITLE
feat: add multi-language tooling

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -687,16 +687,13 @@ require('lazy').setup({
             },
           },
         },
-        -- pyright = {},
-        -- rust_analyzer = {},
-        -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
-        --
-        -- Some languages (like typescript) have entire language plugins that can be useful:
-        --    https://github.com/pmizio/typescript-tools.nvim
-        --
-        -- But for many setups, the LSP (`ts_ls`) will work just fine
-        -- ts_ls = {},
-        --
+        kotlin_language_server = {},
+        ts_ls = {},
+        jdtls = {},
+        intelephense = {},
+        terraformls = {},
+        ansiblels = {},
+        pyright = {},
 
         lua_ls = {
           -- cmd = { ... },
@@ -730,6 +727,14 @@ require('lazy').setup({
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
         'stylua', -- Used to format Lua code
+        'ktlint',
+        'eslint_d',
+        'checkstyle',
+        'phpcs',
+        'tflint',
+        'ansible-lint',
+        'luacheck',
+        'ruff',
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
@@ -960,7 +965,7 @@ require('lazy').setup({
     main = 'nvim-treesitter.configs', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
     opts = {
-      ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
+      ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc', 'kotlin', 'typescript', 'javascript', 'java', 'php', 'terraform', 'python', 'yaml' },
       -- Autoinstall languages that are not installed
       auto_install = true,
       highlight = {

--- a/lua/custom/plugins/debug.lua
+++ b/lua/custom/plugins/debug.lua
@@ -23,6 +23,8 @@ return {
 
     -- Add your own debuggers here
     'leoluz/nvim-dap-go',
+    'mfussenegger/nvim-dap-python',
+    'mxsdev/nvim-dap-vscode-js',
   },
   keys = {
     -- Basic debugging keymaps, feel free to change to your liking!
@@ -95,6 +97,11 @@ return {
       ensure_installed = {
         -- Update this to ensure that you have the debuggers for the langs you want
         'delve',
+        'debugpy',
+        'js-debug-adapter',
+        'kotlin-debug-adapter',
+        'java-debug-adapter',
+        'php-debug-adapter',
       },
     }
 
@@ -144,6 +151,11 @@ return {
         detached = vim.fn.has 'win32' == 0,
         buildFlags = { '-tags=unit,integration' },
       },
+    }
+    require('dap-python').setup(vim.fn.stdpath('data') .. '/mason/packages/debugpy/venv/bin/python')
+    require('dap-vscode-js').setup {
+      debugger_path = vim.fn.stdpath('data') .. '/mason/packages/js-debug-adapter',
+      adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost' },
     }
     dap.configurations.go = vim.list_extend({
       {

--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -7,6 +7,17 @@ return {
       local lint = require 'lint'
       lint.linters_by_ft = {
         markdown = { 'markdownlint' },
+        kotlin = { 'ktlint' },
+        typescript = { 'eslint_d' },
+        javascript = { 'eslint_d' },
+        typescriptreact = { 'eslint_d' },
+        javascriptreact = { 'eslint_d' },
+        java = { 'checkstyle' },
+        php = { 'phpcs' },
+        terraform = { 'tflint' },
+        ansible = { 'ansible_lint' },
+        lua = { 'luacheck' },
+        python = { 'ruff' },
       }
 
       -- To allow other plugins to add linters to require('lint').linters_by_ft,


### PR DESCRIPTION
## Summary
- add LSP servers, Treesitter grammars and tool installer entries for Kotlin, JavaScript/TypeScript, Java, PHP, Terraform, Ansible, Lua and Python
- wire up linters for common languages via nvim-lint
- extend DAP setup with adapters and JS/Python helpers

## Testing
- `nvim --headless "+lua print('loaded')" +qa`


------
https://chatgpt.com/codex/tasks/task_e_68b3576364e483338e96d61e8cfa638d